### PR TITLE
Add ability to specify an explicit source for a given dependency

### DIFF
--- a/lib/cocoapods-core/dependency.rb
+++ b/lib/cocoapods-core/dependency.rb
@@ -19,6 +19,11 @@ module Pod
     #
     attr_accessor :external_source
 
+    # @return [String] The souce URL of the podspec repo to use to resolve
+    #         this dependency. If not set then the standard source list
+    #         should be used to resolve the dependency.
+    attr_accessor :podspec_repo
+
     # @return [Bool] whether the dependency should use the podspec with the
     #         highest know version but force the downloader to checkout the
     #         `head` of the source repository.
@@ -55,6 +60,22 @@ module Pod
     #             Dependency.new('libPusher', {:path    => 'path/to/folder'})
     #             Dependency.new('libPusher', {:podspec => 'example.com/libPusher.podspec'})
     #
+    # @overload   initialize(name, requirements, podspec_repo)
+    #
+    #   @param    [String] name
+    #             the name of the Pod.
+    #
+    #   @param    [Array, Version, String, Requirement] requirements
+    #             an array specifying the version requirements of the
+    #             dependency.
+    #
+    #   @param    [Hash] podspec_repo
+    #             The URL of the specific podspec repo to resolve this dependency from.
+    #
+    #   @example  Initialization with a specific podspec repo
+    #
+    #             Dependency.new('Artsy+UILabels', '~> 1.0', :source => 'https://github.com/Artsy/Specs.git')
+    #
     # @overload   initialize(name, is_head)
     #
     #   @param    [String] name
@@ -69,11 +90,23 @@ module Pod
     #
     def initialize(name = nil, *requirements)
       if requirements.last.is_a?(Hash)
-        external_source = requirements.pop.select { |_, v| !v.nil? }
-        @external_source = external_source unless external_source.empty?
-        unless requirements.empty?
-          raise Informative, 'A dependency with an external source may not ' \
-            "specify version requirements (#{name})."
+        additional_params = requirements.pop.select { |_, v| !v.nil? }
+        additional_params = nil if additional_params.empty?
+
+        if additional_params && additional_params[:source]
+          # This dependency specifies the exact source podspec repo to use.
+          @podspec_repo = additional_params[:source]
+          additional_params.delete(:source)
+          unless additional_params.empty?
+            raise Informative, 'A dependency with a specified podspec repo may ' \
+              "not include other source parameters (#{name})."
+          end
+        else
+          @external_source = additional_params
+          unless requirements.empty?
+            raise Informative, 'A dependency with an external source may not ' \
+              "specify version requirements (#{name})."
+          end
         end
 
       elsif requirements.last == :head
@@ -217,11 +250,11 @@ module Pod
     # @param  [Dependency] other
     #         the other dependency to merge with.
     #
-    # @note   If one of the decencies specifies an external source or is head,
+    # @note   If one of the dependencies specifies an external source or is head,
     #         the resulting dependency preserves this attributes.
     #
-    # @return [Dependency] a dependency (not necessary a new instance) that
-    #         includes also the version requirements of the given one.
+    # @return [Dependency] a dependency (not necessarily a new instance) that
+    #         also includes the version requirements of the given one.
     #
     def merge(other)
       unless name == other.name
@@ -344,7 +377,7 @@ module Pod
     #
     def inspect
       "<#{self.class} name=#{name} requirements=#{requirement} " \
-        "external_source=#{external_source || 'nil'}>"
+        "source=#{podspec_repo || 'nil'} external_source=#{external_source || 'nil'}>"
     end
 
     #--------------------------------------#

--- a/lib/cocoapods-core/podfile/target_definition.rb
+++ b/lib/cocoapods-core/podfile/target_definition.rb
@@ -497,7 +497,7 @@ module Pod
       # @note   The storage of this information is optimized for YAML
       #         readability.
       #
-      # @todo   This needs urgently a rename.
+      # @todo   This urgently needs a rename.
       #
       # @return [void]
       #
@@ -657,8 +657,8 @@ module Pod
 
       # @return [Array<Dependency>] The dependencies inherited by the podspecs.
       #
-      # @note   The podspec directive is intended include the dependencies of a
-      #         spec in the project where it is developed. For this reason the
+      # @note   The podspec directive is intended to include the dependencies of
+      #         a spec in the project where it is developed. For this reason the
       #         spec, or any of it subspecs, cannot be included in the
       #         dependencies. Otherwise it would generate a chicken-and-egg
       #         problem.
@@ -753,7 +753,7 @@ module Pod
         requirements.pop if options.empty?
       end
 
-      # Removes :subspecs form the requirements list, and stores the pods
+      # Removes :subspecs from the requirements list, and stores the pods
       # with the given subspecs as dependencies.
       #
       # @param  [String] name

--- a/lib/cocoapods-core/source.rb
+++ b/lib/cocoapods-core/source.rb
@@ -348,7 +348,7 @@ module Pod
     #
     # @note   In previous versions of CocoaPods they used to be stored in
     #         the root of the repo. This lead to issues, especially with
-    #         the GitHub interface and now the are stored in a dedicated
+    #         the GitHub interface and now they are stored in a dedicated
     #         folder.
     #
     def specs_dir

--- a/lib/cocoapods-core/specification.rb
+++ b/lib/cocoapods-core/specification.rb
@@ -326,7 +326,7 @@ module Pod
 
     # @!group DSL helpers
 
-    # @return [Bool] whether the specification should use a directory as it
+    # @return [Bool] whether the specification should use a directory as its
     #         source.
     #
     def local?

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -18,6 +18,18 @@ module Pod
         dependency.requirement.to_s.should == '> 1.0-pre'
       end
 
+      it 'can be initialized with multiple requirements and a podspec source' do
+        dependency = Dependency.new('bananas', '> 1.0', '< 2.0', :source => 'https://github.com/CocoaPods/CocoaPods.git')
+        dependency.requirement.to_s.should == '< 2.0, > 1.0'
+        dependency.podspec_repo.should == 'https://github.com/CocoaPods/CocoaPods.git'
+      end
+
+      it 'can be initialized with a requirement on a pre-release version and a podspec source' do
+        dependency = Dependency.new('bananas', '> 1.0-pre', :source => 'https://github.com/CocoaPods/CocoaPods.git')
+        dependency.requirement.to_s.should == '> 1.0-pre'
+        dependency.podspec_repo.should == 'https://github.com/CocoaPods/CocoaPods.git'
+      end
+
       it 'can be initialized with an external source' do
         dep = Dependency.new('cocoapods', :git => 'git://github.com/cocoapods/cocoapods')
         dep.should.be.external


### PR DESCRIPTION
This adds the ability to add a `:source` flag to pod dependencies in a Podfile. This behavior mirrors in [Gemfiles](http://bundler.io/gemfile.html), allowing a dependency to be specified as such:

`pod 'JSONKit', '1.4', :source => 'http://github.com/MyOrg/Specs.git'`

An accompanying `CocoaPods` repo PR is coming shortly.
